### PR TITLE
Fix: prefix generation rule while FeatureCreating.

### DIFF
--- a/Application/src/eurocontrol/swim/model/rules/aixm/mapping/AIXM51_Features_MappingRule.java
+++ b/Application/src/eurocontrol/swim/model/rules/aixm/mapping/AIXM51_Features_MappingRule.java
@@ -515,7 +515,7 @@ public class AIXM51_Features_MappingRule  extends AbstractMappingRule implements
 	        {
 	            extensionBaseName = umlParent.GetName() + "Type";
 	        }
-	        extension.setAttribute("base", getNamespacePrefixForElement(feature) + ":" + extensionBaseName);
+	        extension.setAttribute("base", getNamespacePrefixForElement(umlParent) + ":" + extensionBaseName);
 	    }
 	    else
 	    {


### PR DESCRIPTION
When one inherit some aixm:AbstractAixmFeature in extension, one should use aixm prefix for this feature in xsd. 
For example if one inherit `aixm:NavigationSystemCheckpoint`, and use prefix `some_prefix`, then he will get `base="some_prefix:aixm:NavigationSystemCheckpoint"` in xsd, that breaks xsd schema